### PR TITLE
[feat] Stable Diffusion GPU 코드에서 그림 생성 완료/실패 시 SQS에 정보를 보내는 로직을 구성한다.

### DIFF
--- a/gpu-server/aws_sqs.py
+++ b/gpu-server/aws_sqs.py
@@ -1,9 +1,11 @@
 import boto3
 import os
+import json
 
 sqs_client = boto3.client('sqs', region_name='ap-northeast-2')
 
 SPRING_TO_STABLEDIFFUSION_QUEUE_URL= os.environ['SPRING_TO_STABLEDIFFUSION_QUEUE_URL']
+IMAGE_RESPONSE_QUEUE_URL = os.environ['IMAGE_RESPONSE_QUEUE_URL']
 
 NUMBER_OF_MESSAGES_TO_RECEIVE = 5
 
@@ -38,3 +40,33 @@ def delete_message(receipt_handle):
         print("Deleted message from queue.")
     except Exception as e:
         print("An error occurred while deleting message:", str(e))
+
+
+def send_image_success_message(diary_id: int, grid_position: int):
+    try:
+        sqs_client.send_message(
+            QueueUrl=IMAGE_RESPONSE_QUEUE_URL,
+            MessageBody=json.dumps({
+                'diaryId': diary_id,
+                'gridPosition': grid_position,
+                'status': True
+            })
+        )
+        print("Sent image success message to queue.")
+    except Exception as e:
+        print("An error occurred while sending image success message:", str(e))
+
+
+def send_image_failure_message(diary_id: int, grid_position: int):
+    try:
+        sqs_client.send_message(
+            QueueUrl=IMAGE_RESPONSE_QUEUE_URL,
+            MessageBody=json.dumps({
+                'diaryId': diary_id,
+                'gridPosition': grid_position,
+                'status': False
+            })
+        )
+        print("Sent image failure message to queue.")
+    except Exception as e:
+        print("An error occurred while sending image failure message:", str(e))


### PR DESCRIPTION
# [feat] Stable Diffusion GPU 코드에서 그림 완료/실패 시 SQS에 정보를 보내는 로직을 구성한다.
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-408
---
* 구현 내용

- Stable Diffusion GPU 코드에서 그림 생성에 대한 메시지를 SQS에 보내는 로직을 구성하였습니다.

* 추가 발생한 문제(논의 사항)

- 추후 GPU 서버에 존재하는 start.sh의 환경 변수에 IMAGE_RESPONSE_QUEUE_URL를 추가할 필요성이 있습니다.